### PR TITLE
refactor: refactor bad smell InnerClassMayBeStatic

### DIFF
--- a/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
+++ b/LandLord-core/src/main/java/biz/princeps/landlord/commands/Landlordbase.java
@@ -293,7 +293,7 @@ public class Landlordbase extends MainCommand {
         plugin.getUtilsManager().sendBasecomponent(properties.getPlayer(), msg.create());
     }
 
-    public class Confirm extends SubCommand {
+    public static class Confirm extends SubCommand {
 
         public Confirm() {
             super("confirm",


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->## InnerClassMayBeStatic
Inner classes that do not reference their enclosing instances can be made static.
This prevents a common cause of memory leaks and uses less memory per instance of the class.

<!-- fingerprint:937810608 -->
# Repairing Code Style Issues
* InnerClassMayBeStatic (1)
